### PR TITLE
V0.39i: Fixes for Compass compatibility mode

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 Sjasm Z80 Assembler
 
-Copyright (c) 2015 Konamiman
+Copyright (c) 2021 Konamiman
 Based on Sjasm 0.39g6 - Copyright (c) 2006 Sjoerd Mastijn
 
 This software is provided 'as-is', without any express or implied warranty.

--- a/README.txt
+++ b/README.txt
@@ -111,6 +111,15 @@ New in 0.39h (by Konamiman):
 - Added different exit codes for different error conditions. See "Exit codes".
 - &H and &B can be used as prefixes for hexadecimal and binary constants respectively.
 
+New in 0.39i (by Konamiman):
+----------------------------
+- Fix: program crashes without any error message when declaring a Compass-style macro
+  in which the macro name doesn't end with ":".
+- The backslash character, "\", is no longer interpreted as an escape character when running in Compass
+  compatibility mode. So things like 'ld a,"\"' or 'db "\"' work as expected.
+- The TSRHOOKS, .LABEL, .UPPER, and BREAKP directives are now just ignored (instead of throwing errors)
+  when running in Compass compatibility mode.
+
 Known bugs:
 -----------
 - The listfile doesn't always look that good.
@@ -305,7 +314,10 @@ Examples:
   LD A,'"'
   LD A,"'"
 
-In Compass compatibility mode the special constants "" and '' are recognized as being equal to zero.
+When running in Compass compatibility mode:
+- The special constants "" and '' are recognized as being equal to zero.
+- There are no escape sequences, thus the backslash character, "\", is treated as any other character
+  (so e.g. the following works: ld a,"\").
 
 
 Expressions
@@ -1168,8 +1180,11 @@ What's supported when Compass compatibility mode is enabled:
 - Defining macros using the Compass syntax.
 - Local labels inside macros using the "label@sym" syntax.
 - "" and '' constants, being equal to 0.
+- The backslash character, "\", is just a normal character
+  (so no escape sequences are available in strings or in character definitions).
 - Spaces in numeric constants: LD A,% 11 00 11 00.
 - COND and ENDC as synonims for IF and ENDIF, respectively.
+- The TSRHOOKS, .LABEL, .UPPER, and BREAKP directives will just be ignored (instead of throwing an error).
 
 Also when in this mode, multiple POP statements work like in Compass: POP AF,BC,DE is equivalent to POP AF : POP BC : POP DE. This is the reverse of the default Sjasm behavior.
 
@@ -1177,7 +1192,7 @@ What's NOT supported:
 
 - All the infrastructure for generating relocatable files, including the related directives: CSEG, DSEG, ASEG, PUBLIC, EXTRN, .PHASE, .DEPHASE
 - Creating local labels in macros with DEFL.
-- The TSRHOOKS, .LABEL, .UPPER, BREAKP, INCLUDE <number> directives.
+- The INCLUDE <number> directive.
 - Shortened mnemonics (such as LD B as equivalent to LD A,B).
 - Optional parameters in macros:
 

--- a/Sjasm.sln
+++ b/Sjasm.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Sjasm", "Sjasm\Sjasm.vcxproj", "{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}"
 EndProject
@@ -17,27 +17,80 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|ARM.ActiveCfg = Debug|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|x64.ActiveCfg = Debug|Win32
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|x86.ActiveCfg = Debug|Win32
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Debug|x86.Build.0 = Debug|Win32
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|Any CPU.ActiveCfg = Release|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|ARM.ActiveCfg = Release|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|ARM64.ActiveCfg = Release|Win32
+		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|x64.ActiveCfg = Release|Win32
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|x86.ActiveCfg = Release|Win32
 		{F62DEB82-EA5F-4995-85F3-69FFBE6AC80E}.Release|x86.Build.0 = Release|Win32
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|x64.Build.0 = Debug|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Debug|x86.Build.0 = Debug|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|ARM.Build.0 = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|ARM64.Build.0 = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|x64.ActiveCfg = Release|Any CPU
+		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|x64.Build.0 = Release|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|x86.ActiveCfg = Release|Any CPU
 		{1221904E-5397-4AE8-9031-4A716C759E3D}.Release|x86.Build.0 = Release|Any CPU
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM.ActiveCfg = Debug|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM.Build.0 = Debug|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM.Deploy.0 = Debug|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM64.Build.0 = Debug|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x64.ActiveCfg = Debug|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x64.Build.0 = Debug|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x64.Deploy.0 = Debug|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x86.ActiveCfg = Debug|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x86.Build.0 = Debug|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Debug|x86.Deploy.0 = Debug|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|Any CPU.ActiveCfg = Release|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM.ActiveCfg = Release|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM.Build.0 = Release|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM.Deploy.0 = Release|ARM
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM64.ActiveCfg = Release|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM64.Build.0 = Release|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|ARM64.Deploy.0 = Release|ARM64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x64.ActiveCfg = Release|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x64.Build.0 = Release|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x64.Deploy.0 = Release|x64
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x86.ActiveCfg = Release|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x86.Build.0 = Release|x86
+		{1E83A2DD-D9CF-45DF-8DB1-CEA0B44FCB56}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5B95F48D-F262-4F6D-B8C8-C15F9174F94C}
 	EndGlobalSection
 EndGlobal

--- a/Sjasm/Sjasm.vcxproj
+++ b/Sjasm/Sjasm.vcxproj
@@ -20,15 +20,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Sjasm/direct.cpp
+++ b/Sjasm/direct.cpp
@@ -468,6 +468,10 @@ void dirENDTEXTAREA() {
   error("Endt without textarea",0);
 }
 
+void dirNOOP() {
+  while (*lp) lp++;
+}
+
 void dirINCLUDE() {
   char *fnaam;
 #ifdef SECTIONS
@@ -737,6 +741,10 @@ void InsertDirectives() {
   if (compassCompatibilityEnabled) {
 	  dirtab.insertd("cond", dirCOND);
 	  dirtab.insertd("endc", dirENDC);
+      dirtab.insertd(".label", dirNOOP);
+      dirtab.insertd(".upper", dirNOOP);
+      dirtab.insertd("tsrhooks", dirNOOP);
+      dirtab.insertd("breakp", dirNOOP);
   }
 }
 //eof direct.cpp

--- a/Sjasm/parser.cpp
+++ b/Sjasm/parser.cpp
@@ -241,14 +241,14 @@ char *ReplaceDefine(char*lp) {
     if (*lp=='/' && *(lp+1)=='/' && !comlin && !comnxtlin) { *rp=0; return nl; }
     if (*lp=='/' && *(lp+1)=='*') { lp+=2; ++comnxtlin; continue; }
 
-    if (*lp=='"' || *lp=='\'') {
+    if (*lp=='"' || ((!compassCompatibilityEnabled) && *lp == '\'')) {
       a=*lp; if (!comlin && !comnxtlin) { *rp=*lp; ++rp; } ++lp;
       if (a!='\'' || (*(lp-2)!='f' || *(lp-3)!='a') && (*(lp-2)!='F' && *(lp-3)!='A'))
         while ('o') {
           if (!*lp) { *rp=0; return nl; }
           if (!comlin && !comnxtlin) *rp=*lp;
           if (*lp==a) { if (!comlin && !comnxtlin) ++rp; ++lp; break; }
-          if (*lp=='\\') { ++lp; if (!comlin && !comnxtlin) { ++rp; *rp=*lp; } }
+          if (*lp=='\\' && !compassCompatibilityEnabled) { ++lp; if (!comlin && !comnxtlin) { ++rp; *rp=*lp; } }
           if (!comlin && !comnxtlin) ++rp; ++lp;
         }
       continue;
@@ -370,15 +370,14 @@ void ReformatCompassStyleMacro(char* line)
 		return;
 
 	labelStart = line;
-	while(*lp && *lp > ' ' && *lp != ':') lp++;
+	while(*lp && *lp > ' ' && *lp != ':' && *lp != ';') lp++;
 	if (!*lp || *lp == ';')
 		return;
 
 	labelEnd = lp;
 	labelLength = labelEnd - labelStart;
 
-	while (*lp == ':') lp++;
-	while (*lp && *lp <= ' ') ++lp;
+	while (*lp == ':' || *lp == ' ' || *lp == '\t') lp++;
 	if (!*lp)
 		return;
 
@@ -387,7 +386,7 @@ void ReformatCompassStyleMacro(char* line)
 	if (tolower(lp[2]) != 'c') return;
 	if (tolower(lp[3]) != 'r') return;
 	if (tolower(lp[4]) != 'o') return;
-	if (lp[5] > ' ') return;;
+	if (lp[5] > ' ') return;
 
 	lp += 5;
 	while (*lp && *lp <= ' ') ++lp;
@@ -397,15 +396,13 @@ void ReformatCompassStyleMacro(char* line)
 
 	/* It's a Compass style macro */
 
-	memcpy(temp, labelStart, labelLength);
-	temp[labelLength] = '\0';
+    strcpy(temp, " macro ");
+    memcpy(temp + 7, labelStart, labelLength);
+    strcpy(temp + 7 + labelLength, paramsStart - 1);
 
-	strcpy(line, " macro ");
-	strcpy(line + 7, temp);
-	line[7 + labelLength] = ' ';
-	strcpy(line + 7 + labelLength + 1, paramsStart);
+    strcpy(line, temp);
 
-	insideCompassStyleMacroDefinition = 1;
+    insideCompassStyleMacroDefinition = 1;
 }
 
 void ParseLine() {

--- a/Sjasm/reader.cpp
+++ b/Sjasm/reader.cpp
@@ -321,6 +321,11 @@ int getCharConst(char *&p, aint &val) {
 	  p += 2;
 	  return 1;
   }
+  if (compassCompatibilityEnabled && (p[0] == '"' || p[0] == '\'') && p[1] == '\\' && (p[2] == p[0])) {
+      val = '\\';
+      p += 3;
+      return 1;
+  }
   q=*p++;
   do {
     if (!*p || *p==q) { p=op; return 0; }
@@ -345,7 +350,13 @@ int getBytes(char *&p, int e[], int add, int dc) {
       do {
         if (!*p || *p=='"') { error("Syntax error",p,SUPPRES); e[t]=-1; return t; }
         if (t==128) { error("Too many arguments",p,SUPPRES); e[t]=-1; return t; }
-        getCharConstChar(p,val); check8(val); e[t++]=(val+add)&255;
+        if (compassCompatibilityEnabled && *p == '\\') {
+            e[t++] = (92 + add) & 255;
+            p++;
+        }
+        else {
+            getCharConstChar(p, val); check8(val); e[t++] = (val + add) & 255;
+        }
       } while (*p!='"');
       ++p; if (dc && t) e[t-1]|=128;
     } else {

--- a/Sjasm/sjasm.cpp
+++ b/Sjasm/sjasm.cpp
@@ -148,11 +148,11 @@ int main(int argc, char *argv[]) {
   char *p;
   int i=1;
 
-  cout << "SjASM Z80 Assembler v0.39h" << endl;
+  cout << "SjASM Z80 Assembler v0.39i" << endl;
   sourcefilename[0]=destfilename[0]=listfilename[0]=expfilename[0]=0;
   if (argc==1) {
     cout << "Copyright 2006 Sjoerd Mastijn - www.xl2s.tk" << endl;
-	cout << "Copyright 2015 Konamiman - www.konamiman.com" << endl;
+	cout << "Copyright 2021 Konamiman - www.konamiman.com" << endl;
     cout << "\nUsage:\nsjasm [-options] sourcefile [targetfile [listfile [exportfile]]]\n";
     cout << "\nOption flags as follows:\n";
     cout << "  -l        Label table in listing\n";

--- a/Tests/SjasmExecutionTests.cs
+++ b/Tests/SjasmExecutionTests.cs
@@ -317,5 +317,51 @@ data@sym: db 0
             AssertDoesNotCompile(" cond\r\n endif");
             AssertDoesNotCompile(" if\r\n endc");
         }
+
+        [Test]
+        public void Can_declare_backslash_as_single_char_in_compass_compat_mode()
+        {
+            AssertProduceSameCode(" ld a,\"\\\" ;comment", " ld a,92", "-c");
+            AssertProduceSameCode(" ld a,'\\' ;comment", " ld a,92", "-c");
+        }
+
+        [Test]
+        public void Can_declare_escaped_char_when_not_in_compass_compat_mode()
+        {
+            AssertProduceSameCode(" ld a,\"\\t\" ;comment", " ld a,9");
+            AssertProduceSameCode(" ld a,'\\t' ;comment", " ld a,9");
+        }
+
+        [Test]
+        public void Can_use_backslash_as_normal_char_inside_string_in_compass_compat_mode()
+        {
+            AssertProduceSameCode(" db \"AB\\\" ;comment", " db 65,66,92", "-c");
+            AssertProduceSameCode(" db \"AB\\C\" ;comment", " db 65,66,92,67", "-c");
+        }
+
+        [Test]
+        public void Can_use_escaped_char_in_string_when_not_in_compass_compat_mode()
+        {
+            AssertProduceSameCode(" db \"AB\\t\" ;comment", " db 65,66,9");
+            AssertProduceSameCode(" db \"AB\\tC\" ;comment", " db 65,66,9,67");
+        }
+
+        [Test]
+        public void Compass_directives_are_ignored_in_compass_compat_mode()
+        {
+            AssertProduceSameCode(" .label 34\r\n db 0", " db 0", "-c");
+            AssertProduceSameCode(" tsrhooks\r\n db 0", " db 0", "-c");
+            AssertProduceSameCode(" .upper on\r\n db 0", " db 0", "-c");
+            AssertProduceSameCode(" breakp\r\n db 0", " db 0", "-c");
+        }
+
+        [Test]
+        public void Compass_directives_produces_error_when_not_in_compass_compat_mode()
+        {
+            AssertDoesNotCompile(" .label 34\r\n db 0");
+            AssertDoesNotCompile(" tsrhooks\r\n db 0");
+            AssertDoesNotCompile(" .upper on\r\n db 0");
+            AssertDoesNotCompile(" breakp\r\n db 0");
+        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.4.1.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.1.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.13.2\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Konamiman.Sjasm.Tests</RootNamespace>
     <AssemblyName>Sjasm.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,9 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.13.2.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.2\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -53,6 +57,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.2\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.1.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.1.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/TestsClass.cs
+++ b/Tests/TestsClass.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework;
 
 namespace Konamiman.Sjasm.Tests
@@ -9,7 +10,10 @@ namespace Konamiman.Sjasm.Tests
     {
         protected ExecutionResult ExecuteSjasm(string arguments)
         {
-            var startInfo = new ProcessStartInfo(@"..\..\bin\sjasm.exe", arguments) {
+            var myPath = new Uri(Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase)).LocalPath;
+            var sjasmPath = Path.Combine(myPath, "../../bin/Sjasm.exe");
+
+            var startInfo = new ProcessStartInfo(sjasmPath, arguments) {
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" userInstalled="true" />
+  <package id="NUnit" version="3.13.2" targetFramework="net48" userInstalled="true" />
+  <package id="NUnit3TestAdapter" version="4.1.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Improvements for the Compass compatibility mode:

- Fix: program crashes without any error message when declaring a Compass-style macro in which the macro name doesn't end with `:`.
- The backslash character, `\`, is no longer interpreted as an escape character when running in Compass compatibility mode.
  So things like `ld a,"\"` or `db "\"` now work as expected.
- The `TSRHOOKS`,  `.LABEL`, `.UPPER`, and `BREAKP` directives are now just ignored (instead of throwing errors) when running in Compass compatibility mode.

Also changed the character set setting from "Unicode" to "Not set" in the Visual Studio project, otherwise it wouldn't compile.