### PR TITLE
V0.39j: Fix the MODULE directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 .deps/
 Sjasm/sjasm
 *.vcxproj.user
+Debug/
+bin/
+.vs/
+packages/
+*.asm
+*.lst
+*.sym
+*.out
+sjasm_linux

--- a/Sjasm/Sjasm.vcxproj
+++ b/Sjasm/Sjasm.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile Include="parser.cpp" />
     <ClCompile Include="piz80.cpp" />
     <ClCompile Include="reader.cpp" />
-    <ClCompile Include="Sjasm.cpp" />
+    <ClCompile Include="sjasm.cpp" />
     <ClCompile Include="sjio.cpp" />
     <ClCompile Include="tables.cpp" />
   </ItemGroup>

--- a/Sjasm/Sjasm.vcxproj.filters
+++ b/Sjasm/Sjasm.vcxproj.filters
@@ -44,7 +44,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Sjasm.cpp">
+    <ClCompile Include="sjasm.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="direct.cpp">

--- a/Sjasm/direct.cpp
+++ b/Sjasm/direct.cpp
@@ -314,8 +314,14 @@ void dirMODULE() {
 #ifdef SECTIONS
   if (section!=TEXT) { error(".module only allowed in text sections",0); *lp=0; return; }
 #endif
-  modlstp=new stringlst(modlabp,modlstp);
   char *n;
+  stringlst* old_modlstp;
+
+  old_modlstp = modlstp;
+  modlstp=new stringlst();
+  modlstp->string=modlabp;
+  modlstp->next=old_modlstp;
+
   skipblanks(lp); if (!*lp) { modlabp=0; return; }
   if (n=getid(lp)) modlabp=n; else error("Syntax error",0,CATCHALL);
 }

--- a/Sjasm/sjasm.cpp
+++ b/Sjasm/sjasm.cpp
@@ -148,11 +148,11 @@ int main(int argc, char *argv[]) {
   char *p;
   int i=1;
 
-  cout << "SjASM Z80 Assembler v0.39i" << endl;
+  cout << "SjASM Z80 Assembler v0.39j" << endl;
   sourcefilename[0]=destfilename[0]=listfilename[0]=expfilename[0]=0;
   if (argc==1) {
     cout << "Copyright 2006 Sjoerd Mastijn - www.xl2s.tk" << endl;
-	cout << "Copyright 2021 Konamiman - www.konamiman.com" << endl;
+	cout << "Copyright 2022 Konamiman - www.konamiman.com" << endl;
     cout << "\nUsage:\nsjasm [-options] sourcefile [targetfile [listfile [exportfile]]]\n";
     cout << "\nOption flags as follows:\n";
     cout << "  -l        Label table in listing\n";

--- a/Tests/SjasmExecutionTests.cs
+++ b/Tests/SjasmExecutionTests.cs
@@ -363,5 +363,49 @@ data@sym: db 0
             AssertDoesNotCompile(" .upper on\r\n db 0");
             AssertDoesNotCompile(" breakp\r\n db 0");
         }
+
+        [Test]
+        public void Modules_work()
+        {
+            var program1Source =
+@"
+    org 100h;
+
+    jp label1
+    jp label2
+    jp label3
+    jp label4
+    jp label5
+
+label1: nop
+label2: nop
+label3: nop
+label4: nop
+label5: nop
+";
+
+            var program2Source =
+@"
+    org 100h;
+
+    jp label1
+    jp X.label2
+    jp Y.label3
+    jp X.label4
+    jp label5
+
+label1: nop
+    MODULE X
+label2: nop
+    MODULE Y
+label3: nop
+    ENDMODULE
+label4: nop
+    ENDMODULE
+label5: nop
+";
+
+            AssertProduceSameCode(program1Source, program2Source);
+        }
     }
 }


### PR DESCRIPTION
Modules were not working. The `MODULE` directive was causing a "segmentation fault" error in Linux, and the compilation process to abruptly stop in Windows.