### PR TITLE
Fix compilation errors on GCC 11.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+Sjasm/sjasm
+Sjasm/.deps

--- a/Sjasm/datadir.cpp
+++ b/Sjasm/datadir.cpp
@@ -28,8 +28,8 @@
 
 #include "sjasm.h"
 
-byte map[256];
-byte smap[256];
+BYTE map[256];
+BYTE smap[256];
 
 void getbytes(string &line, Data &e, bool madd, bool usemap, bool canval, bool dc, bool dz) {
   int val,add=0,len=0,glabelnotfound=0;
@@ -100,7 +100,7 @@ void piDD(string line,Data &e) {
   int val;
   do {
     if (ParseExpression(line,val)) {
-      for (int i=0;i!=4;++i) { e.push((byte)val); val>>=8; }
+      for (int i=0;i!=4;++i) { e.push((BYTE)val); val>>=8; }
     } else { error("Syntax error"); return; }
   } while (comma(line));
   checkjunk(line);
@@ -110,7 +110,7 @@ void piDT(string line,Data &e) {
   int val;
   do {
     if (ParseExpression(line,val)) {
-      check24(val); for (int i=0;i!=3;++i) { e.push((byte)val); val>>=8; }
+      check24(val); for (int i=0;i!=3;++i) { e.push((BYTE)val); val>>=8; }
     } else { error("Syntax error"); return; }
   } while (comma(line));
   checkjunk(line);
@@ -120,7 +120,7 @@ void piDW(string line,Data &e) {
   int val;
   do {
     if (ParseExpression(line,val)) {
-      check16(val); e.push((byte)val); e.push((byte)(val>>8));
+      check16(val); e.push((BYTE)val); e.push((BYTE)(val>>8));
     } else { error("Syntax error"); return; }
   } while (comma(line));
   checkjunk(line);
@@ -170,7 +170,7 @@ void piASCMAP(string line, Data &) {
     if (comma(line)) {
       if (!ParseExpression(line,a)) { error("Increment expected"); return; }
     } else a=1;
-    for (int i=first; i!=last; ++i) { check8(b); map[i]=(byte)b; b+=a; }
+    for (int i=first; i!=last; ++i) { check8(b); map[i]=(BYTE)b; b+=a; }
   } else {
     int oadres=adres;
     for (int i=first; i!=last; ++i) {
@@ -178,7 +178,7 @@ void piASCMAP(string line, Data &) {
       int e;
       adres=i; // terrible hack :)
       if (!ParseExpression(l,e)) break;
-      check8(e);  map[i]=(byte)e;
+      check8(e);  map[i]=(BYTE)e;
     }
     adres=oadres;
   }
@@ -186,7 +186,7 @@ void piASCMAP(string line, Data &) {
 }
 
 void piASCMAPRESET(string line, Data &) {
-  for (int i=0; i!=256; ++i) map[i]=(byte)i;
+  for (int i=0; i!=256; ++i) map[i]=(BYTE)i;
   again=1; checkjunk(line);
 }
 
@@ -310,7 +310,7 @@ void initPidata() {
     "defm",pdDB
   };
   datafuntab.init(funs, sizeof funs/sizeof funs[0]);
-  for (int i=0; i!=256; ++i) smap[i]=map[i]=(byte)i;
+  for (int i=0; i!=256; ++i) smap[i]=map[i]=(BYTE)i;
 }
 
 //eof

--- a/Sjasm/datastructures.cpp
+++ b/Sjasm/datastructures.cpp
@@ -50,8 +50,8 @@ void Data::_grow(int nsize) {
 }
 
 void Data::_resize(int nsize) {
-  byte *odata=_data;
-  _data=new byte[nsize];
+  BYTE *odata=_data;
+  _data=new BYTE[nsize];
   memset(_data+_size,0,nsize-_size);
   if (odata) {
     memcpy(_data,odata,_size);
@@ -654,19 +654,19 @@ void Structure::emitdata(string line, Data &e, string label) {
       case 0: break;
       case 1:
         if (!ParseExpression(d,val)) error("Syntax error"); checkjunk(d);
-        val=check8(val); e.push((byte)val);
+        val=check8(val); e.push((BYTE)val);
         break;
       case 2:
         if (!ParseExpression(d,val)) error("Syntax error"); checkjunk(d);
-        val=check16(val); e.push((byte)val); e.push((byte)(val>>8));
+        val=check16(val); e.push((BYTE)val); e.push((BYTE)(val>>8));
         break;
       case 3:
         if (!ParseExpression(d,val)) error("Syntax error"); checkjunk(d);
-        val=check24(val); for (int i=0;i!=3;++i) { e.push((byte)val); val>>=8; }
+        val=check24(val); for (int i=0;i!=3;++i) { e.push((BYTE)val); val>>=8; }
         break;
       case 4:
         if (!ParseExpression(d,val)) error("Syntax error"); checkjunk(d);
-        /*val=check32(val);*/ for (int i=0;i!=4;++i) { e.push((byte)val); val>>=8; }
+        /*val=check32(val);*/ for (int i=0;i!=4;++i) { e.push((BYTE)val); val>>=8; }
         break;
       case 5:
         f.clear();

--- a/Sjasm/datastructures.h
+++ b/Sjasm/datastructures.h
@@ -33,7 +33,7 @@ typedef IntList::iterator iIntList;
 typedef vector<string> StringList;
 typedef StringList::iterator iStringList;
 typedef string::iterator istring;
-typedef unsigned char byte;
+typedef unsigned char BYTE;
 
 class RawSource;
 typedef void(*pFun)(string&,RawSource*);
@@ -47,23 +47,23 @@ class Data {
 public:
   Data() : _data(0), _size(0), _maxsize(4)  { _resize(_maxsize); }
   Data(int n_maxsize) : _data(0), _size(0), _maxsize(n_maxsize) { _resize(_maxsize); }
-  Data(byte *n_data,int n_size) : _data(0), _size(n_size), _maxsize(n_size) { _resize(n_size); memcpy(_data,n_data,n_size); }
+  Data(BYTE *n_data,int n_size) : _data(0), _size(n_size), _maxsize(n_size) { _resize(n_size); memcpy(_data,n_data,n_size); }
   ~Data() { delete [] _data; }
-  void setdata(byte *buffer, int size) { _data=new byte[size]; memcpy(_data,buffer,size); _size=_maxsize=size; }
-  void push(byte n_byte) { if (_size>=_maxsize) _grow(_size); _data[_size]=n_byte; ++_size; }
+  void setdata(BYTE *buffer, int size) { _data=new BYTE[size]; memcpy(_data,buffer,size); _size=_maxsize=size; }
+  void push(BYTE n_byte) { if (_size>=_maxsize) _grow(_size); _data[_size]=n_byte; ++_size; }
   void push(const Data &n_data) { 
     if (_size+n_data._size>=_maxsize) _grow(_size+n_data._size);
     memcpy(_data+_size,n_data._data,n_data._size);
     _size+=n_data._size;
   }
-  byte operator[](int index) const { return _data[index]; }
-  byte &operator[](int index) { if (index>=_maxsize) _grow(index); if (_size<=index) _size=index+1; return _data[index]; }
+  BYTE operator[](int index) const { return _data[index]; }
+  BYTE &operator[](int index) { if (index>=_maxsize) _grow(index); if (_size<=index) _size=index+1; return _data[index]; }
   int size() { return _size; }
   void clear() { _size=0; }
-  byte *getdatap(int offset=0) { return _data+offset; }
+  BYTE *getdatap(int offset=0) { return _data+offset; }
   bool empty() { return _size==0; }
 private:
-  byte *_data;
+  BYTE *_data;
   int _size,_maxsize;
   void _grow(int);
   void _resize(int);

--- a/Sjasm/fileio.h
+++ b/Sjasm/fileio.h
@@ -38,11 +38,11 @@ public:
   ReadFile(string);
   ~ReadFile();
   void readtostringlist(StringList&);
-  void getbuffer(byte *&buffer,int &size) { buffer=_buffer; size=_size; }
+  void getbuffer(BYTE *&buffer,int &size) { buffer=_buffer; size=_size; }
   bool ok() { return _buffer!=0; }
 private:
   int _size;
-  byte *_buffer;
+  BYTE *_buffer;
 };
 
 class WriteFile {

--- a/Sjasm/output.h
+++ b/Sjasm/output.h
@@ -141,7 +141,7 @@ public:
   int pageok(int np) { if (_page.empty() || (unsigned)np>=_page.size()) return 0; return _page[np]!=0; }
   void emit(Data &e) { if (!e.size()) return; if (!_outp) getroutp(); _outp->emit(e); adres+=e.size(); }
   int pool(int d) { if (!_outp) getroutp(); return _outp->pool(d); }
-  void emitblock(int d, int len) { Data e; while (len--) e.push((byte)d); emit(e); }
+  void emitblock(int d, int len) { Data e; while (len--) e.push((BYTE)d); emit(e); }
   void reset();
   void dump(StringList&);
   void sort();

--- a/Sjasm/pimsx.cpp
+++ b/Sjasm/pimsx.cpp
@@ -968,7 +968,7 @@ void pmLD(string line,Data &e) {
     case Z80_BC: case Z80_DE: case Z80_SP: e.push(0xed); e.push(0x33+y.reg); break;
     }
     if (!e.size()) break;
-    check16(x.val); e.push((byte)x.val); e.push((byte)(x.val>>8));
+    check16(x.val); e.push((BYTE)x.val); e.push((BYTE)(x.val>>8));
     break;
   case Z80_A:
     switch (y.reg) {
@@ -976,7 +976,7 @@ void pmLD(string line,Data &e) {
       preinc(e,y); e.push(0x0a); postinc(e,y); break;
     case Z80mDE: case Z80miDE: case Z80mdDE: case Z80mDEi: case Z80mDEd: 
       preinc(e,y); e.push(0x1a); postinc(e,y); break;
-    case Z80mnn: e.push(0x3a); check16(y.val); e.push((byte)y.val); e.push((byte)(y.val>>8)); break;
+    case Z80mnn: e.push(0x3a); check16(y.val); e.push((BYTE)y.val); e.push((BYTE)(y.val>>8)); break;
     case Z80_I: e[0]=0xed; e[1]=0x57; break;
     case Z80_R: e[0]=0xed; e[1]=0x5f; break;
     }
@@ -1011,7 +1011,7 @@ void pmLD(string line,Data &e) {
     case Z80_nn: e.push(x.reg-15); break;
     }
     if (!e.size()) break;
-    check16(y.val); e.push((byte)y.val); e.push((byte)(y.val>>8));
+    check16(y.val); e.push((BYTE)y.val); e.push((BYTE)(y.val>>8));
     break;
   case Z80_I:
     if (y.reg!=Z80_A) break;
@@ -1023,7 +1023,7 @@ void pmLD(string line,Data &e) {
     case Z80_nn: e.push(x.reg); e.push(0x21); break;
     }
     if (!e.size()) break;
-    check16(y.val); e.push((byte)y.val); e.push((byte)(y.val>>8));
+    check16(y.val); e.push((BYTE)y.val); e.push((BYTE)(y.val>>8));
     break;
   case Z80_IXH: case Z80_IXL: case Z80_IYH: case Z80_IYL:
     switch (y.reg) {

--- a/Sjasm/reader.cpp
+++ b/Sjasm/reader.cpp
@@ -277,7 +277,7 @@ void getstring(string &s,string &e) {
     do {
       int val;
       if (s.empty() || s[0]=='"') { error("Syntax error",ERRREP); break; }
-      getcharconstchar(s,val); e.push_back((byte)val);
+      getcharconstchar(s,val); e.push_back((BYTE)val);
     } while (s[0]!='"');
     s.erase(0,1);
   } else

--- a/Sjasm/source.cpp
+++ b/Sjasm/source.cpp
@@ -468,7 +468,7 @@ dIncbin::dIncbin(std::string n_line, bool list) : _line(n_line),_listinfo(0) {
   string n;
   ReadFile file(getpath(n=getfilename(_line)));
   if (file.ok()) {
-    byte *buffer; int size;
+    BYTE *buffer; int size;
     file.getbuffer(buffer,size);
     _data.setdata(buffer,size);
   }


### PR DESCRIPTION
GCC 11.3.0 (used on Ubuntu 22.04) was refusing to compile Sjasm 0.42 because `byte` is now a built-in type in the C++ standard library.  To fix this, I have renamed it to `BYTE` (all caps) everywhere in the sjasm code so it does not cause a conflict.  Now it compiles and I have tested it on several programs, and the output still looks correct.  I also added a `.gitignore` to prevent `.o` files from getting committed.